### PR TITLE
ci: Add component upload GH action (AIV-648)

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,0 +1,20 @@
+name: Upload component to IDF Component Registry
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Upload esp-dl
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: "esp-dl"
+          namespace: "espressif"
+          version: ${{ github.ref_name }}
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
Hello @Auroragan 
Here is simple PR that adds GH action that uploads esp-dl component to [IDF Component Registry](https://components.espressif.com/).
Few points:

* You will have to add a GH secret named IDF_COMPONENT_API_TOKEN to you GH project (here's a [docu link](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) ICYMI). @kumekay) can generate one for you
* The GH action will run on every time a tag is pushed (eg 1.0.1 or v1.0.1), so it expects that you tag your releases. (there is also an option to bump the version manually in idf_component.yml , but this is recommended for repositories that contain more than 1 component)
* I can see that in your [idf_component.yml](https://components.espressif.com/) you support only esp-idf 5.0.x . Are you sure this cannot be extended to 5.* ? Are there any blockers to support IDF 5.1 and 5.2?

Closes #135 