### PR TITLE
chore: Update idf_component.yml with links (AIV-665)

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,6 @@
-description: esp_dl provides APIs for Neural Network (NN) Inference, Image Processing, Math Operations and some Deep Learning Models.
+description: ESP Deap Learning: APIs for Neural Network (NN) Inference, Image Processing, Math Operations and some Deep Learning Models
+url: https://github.com/espressif/esp-dl
+documentation: "https://docs.espressif.com/projects/esp-dl/en/latest/esp32s3/index.html"
+repository: "https://github.com/espressif/esp-dl.git"
 dependencies:
   idf: ">=5.0.0"


### PR DESCRIPTION
Hello,
just a small update of idf_component.yml with additional links.

When do you plan to release new version `2.0.1` ?
The latest 2.0.0 does not support IDF 5.1 and above...
https://components.espressif.com/components/espressif/esp-dl