### PR TITLE
fix channel order in convert_to_u8 tool (AIV-676)

### DIFF
--- a/examples/tool/convert_to_u8.py
+++ b/examples/tool/convert_to_u8.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
         quit()
 
     image = cv2.imread(args.input)
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     h,w,c=image.shape
 
     with open(args.output, 'w') as file:


### PR DESCRIPTION
OpenCV imread function loads images in BGR order. ESP-DL required RGB channel ordering, so BGR to RGB conversion is required.