### PR TITLE
Add missing constructor form mem_info (AIV-781)

### DIFF
--- a/esp-dl/dl/dl_define.hpp
+++ b/esp-dl/dl/dl_define.hpp
@@ -148,6 +148,10 @@ public:
     size_t psram;    /*!< PSRAM usage */
     size_t internal; /*!< internal RAM usage */
     size_t flash;    /*!< FLASH usage */
+
+    mem_info(size_t psram = 0, size_t internal = 0, size_t flash = 0)
+    : psram(psram), internal(internal), flash(flash) {}
+
     mem_info operator+(const mem_info &other) const
     {
         return mem_info(psram + other.psram, internal + other.internal, flash + other.flash);


### PR DESCRIPTION
## Description
The new operators added in mem_info class in cf44e40 just broke the compilation, since they need a constructor candidate with the 3 class parameters. I add the missing constructor. 

## Testing
Tested on IDF 5.4.1 with a project on ESP32P4 Kit. 
Windows 11 machine

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
