### PR TITLE
test: add circular access in TensorBase::assign

### DIFF
--- a/esp-dl/dl/tensor/include/dl_tensor_base.hpp
+++ b/esp-dl/dl/tensor/include/dl_tensor_base.hpp
@@ -147,10 +147,11 @@ public:
      * @brief Assign tensor to this tensor
      *
      * @param tensor
+     * @param start_position The starting index in src_data from which to begin copying data.
      *
      * @return ture if assign successfully, otherwise false.
      */
-    bool assign(TensorBase *tensor);
+    bool assign(TensorBase *tensor, int start_position = 0);
 
     /**
      * @brief Assign data to this tensor


### PR DESCRIPTION
Implement circular access with start_position in
TensorBase::assign() for the INT8 data type.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Optimize handling of circular data to avoid extra copy costs. For time-sequence data like 
`[1, 2, 3, 4, 5]`, 
when new data (6) arrives, instead of shifting all elements to 
`[2, 3, 4, 5, 6]`, 
we update `start_position` to `1` (value `2`) represent the start index:
`[6, 2, 3, 4, 5]`. 
The storage method for new data uses circular indexing as shown below:
```current_idx = (current_idx + 1) % WINDOW_SIZE;```

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Tested on esp-idf-v5.3.1 with arch linux x86_64 on esp32s3
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
