### PR TITLE
feat: support grayscale images in preprocessor (AIV-804)

### DIFF
--- a/esp-dl/vision/image/dl_image_preprocessor.cpp
+++ b/esp-dl/vision/image/dl_image_preprocessor.cpp
@@ -15,12 +15,16 @@ ImagePreprocessor::ImagePreprocessor(Model *model,
 {
     m_model_input = model->get_input(input_name);
     assert(m_model_input->dtype == DATA_TYPE_INT8 || m_model_input->dtype == DATA_TYPE_INT16);
-    assert(m_model_input->shape[3] == mean.size() && mean.size() == std.size());
+    int ch = (int)m_model_input->shape[3];
+    assert(ch == mean.size() && mean.size() == std.size());
     img_t dst = {.data = m_model_input->data,
                  .width = (uint16_t)m_model_input->shape[2],
                  .height = (uint16_t)m_model_input->shape[1],
-                 .pix_type = (m_model_input->dtype == DATA_TYPE_INT8) ? DL_IMAGE_PIX_TYPE_RGB888_QINT8
-                                                                      : DL_IMAGE_PIX_TYPE_RGB888_QINT16};
+                 .pix_type = (ch == 1)
+                                 ? ((m_model_input->dtype == DATA_TYPE_INT8) ? DL_IMAGE_PIX_TYPE_GRAY_QINT8
+                                                                             : DL_IMAGE_PIX_TYPE_GRAY_QINT16)
+                                 : ((m_model_input->dtype == DATA_TYPE_INT8) ? DL_IMAGE_PIX_TYPE_RGB888_QINT8
+                                                                             : DL_IMAGE_PIX_TYPE_RGB888_QINT16)};
     NormQuantWrapper::quant_type_t quant_type =
         (m_model_input->dtype == DATA_TYPE_INT8) ? NormQuantWrapper::INT8_QUANT : NormQuantWrapper::INT16_QUANT;
     m_image_transformer.set_dst_img(dst).set_caps(caps).set_norm_quant_param(


### PR DESCRIPTION
## Description
For our use case we classify grayscale images. The ImagePreprocesser currently only expects rgb888 images. So I changed it to also expect grayscale and choose the quantization accordingly. 

## Testing
I tested this on an esp32s3. I can provide a squeezenet model which uses 96x96px grayscale images as input on request.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
