### PR TITLE
fix(p4): use pre-v3 instruction variants on older P4 chip revisions

### DIFF
--- a/esp-dl/idf_component.yml
+++ b/esp-dl/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.3.0"
+version: "3.3.1"
 license: "MIT"
 targets:
   - esp32

--- a/esp-dl/vision/image/isa/esp32p4/dl_esp32p4_color_common.S
+++ b/esp-dl/vision/image/isa/esp32p4/dl_esp32p4_color_common.S
@@ -1,7 +1,7 @@
 #include "sdkconfig.h"
 #include "esp_idf_version.h"
 
-#if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2))
+#if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2)) || defined(CONFIG_ESP32P4_SELECTS_REV_LESS_V3)
 .macro vldbc_8_ip q, a, n
     esp.vldbc.8.ip \q, \a, \n * 4
 .endm
@@ -73,7 +73,7 @@
         .error "unsupported n"
     .endif
     esp.vldbc.8.ip \q_tmp, \a_tmp, 0
-#if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2))
+#if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2)) || defined(CONFIG_ESP32P4_SELECTS_REV_LESS_V3)
     esp.vsld.8 \qd, \qs, \q_tmp
 #else
     esp.vsld.8 \qd, \qs, \q_tmp, trunc


### PR DESCRIPTION
## Summary

- The `esp.vsld.8 ... trunc` operand and the changed `esp.vldbc.{8,16}.ip` immediate encoding are only available on ESP32-P4 v3.0+ (ECO5+)
- The existing preprocessor guard only checks IDF version (`>= 5.5.2`) but not the chip revision, causing assembly errors when building for pre-v3 P4 chips on IDF 5.5.x
- Added `|| defined(CONFIG_ESP32P4_SELECTS_REV_LESS_V3)` to both guards in `dl_esp32p4_color_common.S`
- Bumped version to 3.3.1

## Error without fix

```
dl_esp32p4_color_common.S:79: Error: illegal operands `esp.vsld.8 q2,q0,q4,trunc'
```

## Test plan
- [x] Build with `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` (pre-v3 chip) — uses old instruction variants
- [ ] Build with v3+ chip (default) — uses `trunc` variant as before