### PR TITLE
fix(esp32p4 with idf-v6.0): compiling errors with ESP-IDF v6.0 on ESP32-P4: outdated esp-dsp dependency and mbedtls/aes.h 

### DIFF
--- a/esp-dl/fbs_loader/src/fbs_loader.cpp
+++ b/esp-dl/fbs_loader/src/fbs_loader.cpp
@@ -1,5 +1,11 @@
 #include "fbs_loader.hpp"
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "psa/crypto.h"
+#else
 #include "mbedtls/aes.h"
+#endif
 
 static const char *TAG = "FbsLoader";
 
@@ -18,15 +24,38 @@ namespace fbs {
  */
 void fbs_aes_crypt_ctr(const uint8_t *ciphertext, uint8_t *plaintext, size_t size, const uint8_t *key)
 {
-    mbedtls_aes_context aes_ctx;
-    size_t offset = 0;
     uint8_t nonce[16] = {
         0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F};
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_id_t key_id = PSA_KEY_ID_NULL;
+    psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
+    size_t output_length = 0;
+
+    psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_ENCRYPT);
+    psa_set_key_algorithm(&key_attributes, PSA_ALG_CTR);
+    psa_set_key_type(&key_attributes, PSA_KEY_TYPE_AES);
+    psa_set_key_bits(&key_attributes, 128);
+    psa_import_key(&key_attributes, key, 16, &key_id);
+    psa_reset_key_attributes(&key_attributes);
+
+    psa_cipher_encrypt_setup(&operation, key_id, PSA_ALG_CTR);
+    psa_cipher_set_iv(&operation, nonce, sizeof(nonce));
+    psa_cipher_update(&operation, ciphertext, size, plaintext, size, &output_length);
+
+    uint8_t finish_buf[16];
+    size_t finish_len;
+    psa_cipher_finish(&operation, finish_buf, sizeof(finish_buf), &finish_len);
+    psa_destroy_key(key_id);
+#else
+    mbedtls_aes_context aes_ctx;
+    size_t offset = 0;
     uint8_t stream_block[16];
     mbedtls_aes_init(&aes_ctx);
     mbedtls_aes_setkey_enc(&aes_ctx, key, 128); // 128-bit key
     mbedtls_aes_crypt_ctr(&aes_ctx, size, &offset, nonce, stream_block, ciphertext, plaintext);
     mbedtls_aes_free(&aes_ctx);
+#endif
 }
 
 /**

--- a/esp-dl/idf_component.yml
+++ b/esp-dl/idf_component.yml
@@ -20,7 +20,7 @@ dependencies:
         version: ">=5.5"
   espressif/esp_new_jpeg: "^0.6.1"
   espressif/dl_fft: ">=0.3.1"
-  espressif/esp-dsp: "==1.7.0"
+  espressif/esp-dsp: "==1.8.0"
 examples:
   - path: ../examples/tutorial/how_to_deploy_streaming_model
   - path: ../examples/tutorial/how_to_load_test_profile_model/model_in_flash_partition


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
- **mbedtls/aes.h removed from public API**: IDF v6.0 upgrades mbedtls to v4.x (TF-PSA-Crypto). 

    Fix: use PSA Crypto API for IDF >= 6.0, retaining the original `mbedtls_aes_*` path for IDF < 6.0.

- **esp-dsp 1.7.0 incompatible with IDF v6.0**: kalman filter modules in esp-dsp 1.7.0 is not compatible with IDF v6.0, causing `std::cos`/`std::sin` to be undeclared. 

    Fix: bump dependency to esp-dsp 1.8.0 which contains the fix. (was fixed in esp-dsp v1.7.1, see commit https://github.com/espressif/esp-dsp/commit/23ee959982b90a1a920b2198b7e380797f39fee1)

**esp.vsld.8 and vldbc_8_ip illegal operands** also prevents compiling with esp32p4 (rev 1.0) and IDF v6.0. However this is fixed in pull request #294 (not merged yet at the moment)

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
Issue: #295
Pull request: #294 
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Tested with IDF v6.0 and IDF v5.5.1 on esp32p4 (rev 1.0), both compilied successfully. 
Tested with mobilenet-v2, `espdl` model loading and inferernce are successful.
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
