### PR TITLE
dl: reuse static workers in dual-core module runtime

### DIFF
--- a/esp-dl/dl/module/include/dl_module_base.hpp
+++ b/esp-dl/dl/module/include/dl_module_base.hpp
@@ -140,64 +140,13 @@ public:
 };
 
 /**
- * @brief The data struct of module task. Pack all necessary information as the input for module task.
- */
-typedef struct {
-    Module *op;                   ///< Module instance pointer
-    void *args;                   ///< ArgsType, arithArgsType, resizeArgsType and so on
-    SemaphoreHandle_t &semaphore; ///< recommend xSemaphoreCreateCounting
-} module_task_data_t;
-
-/**
- * @brief The function of module task.
- * @param args The data of module task.
- */
-static void module_forward_task(void *args)
-{
-    module_task_data_t *task = (module_task_data_t *)args;
-    task->op->forward_args(task->args);
-    xSemaphoreGive(task->semaphore);
-    vTaskSuspend(NULL);
-}
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-/**
  * @brief Run the module with dual core and use semaphores to keep tasks in sync
  *
  * @param op            Module instance
  * @param args1         Task1 args: ArgsType, arithArgsType, resizeArgsType and so on
  * @param args2         Task2 args: ArgsType, arithArgsType, resizeArgsType and so on
  */
-static void module_forward_dual_core(Module *op, void *args1, void *args2)
-{
-    BaseType_t current_core_id = xPortGetCoreID();
-    UBaseType_t current_priority = uxTaskPriorityGet(xTaskGetCurrentTaskHandle());
-    SemaphoreHandle_t semaphore = xSemaphoreCreateCounting(2, 0);
-    TaskHandle_t xHandleTask1, xHandleTask2;
-
-    module_task_data_t task_data1 = {
-        .op = op,
-        .args = args1,
-        .semaphore = semaphore,
-    };
-    xTaskCreatePinnedToCore(
-        module_forward_task, NULL, 2048, &task_data1, current_priority, &xHandleTask1, (current_core_id + 1) % 2);
-
-    module_task_data_t task_data2 = {
-        .op = op,
-        .args = args2,
-        .semaphore = semaphore,
-    };
-    xTaskCreatePinnedToCore(
-        module_forward_task, NULL, 2048, &task_data2, current_priority, &xHandleTask2, current_core_id);
-
-    xSemaphoreTake(semaphore, portMAX_DELAY);
-    xSemaphoreTake(semaphore, portMAX_DELAY);
-    vSemaphoreDelete(semaphore);
-    vTaskDelete(xHandleTask1);
-    vTaskDelete(xHandleTask2);
-}
-#pragma GCC diagnostic pop
+void module_forward_dual_core(Module *op, void *args1, void *args2);
 
 } // namespace module
 } // namespace dl

--- a/esp-dl/dl/module/src/dl_module_base.cpp
+++ b/esp-dl/dl/module/src/dl_module_base.cpp
@@ -1,10 +1,99 @@
 #include "dl_module_base.hpp"
+
+#include <assert.h>
+#include <freertos/idf_additions.h>
+#include <freertos/semphr.h>
 #include <string.h>
 
 using namespace dl;
 
 namespace dl {
 namespace module {
+
+namespace {
+
+#if CONFIG_FREERTOS_NUMBER_OF_CORES > 1
+
+constexpr size_t kWorkerCount = 2;
+constexpr uint32_t kWorkerStackBytes = 2048;
+constexpr UBaseType_t kWorkerDefaultPriority = tskIDLE_PRIORITY + 1;
+
+struct DualCoreWorkerRuntime;
+
+struct DualCoreWorkerTaskArgs {
+    DualCoreWorkerRuntime *runtime = nullptr;
+    size_t slot = 0;
+};
+
+struct DualCoreWorkerRuntime {
+    StaticSemaphore_t dispatch_mutex_buffer = {};
+    SemaphoreHandle_t dispatch_mutex = nullptr;
+    StaticSemaphore_t completion_buffer = {};
+    SemaphoreHandle_t completion = nullptr;
+    StaticTask_t task_buffers[kWorkerCount] = {};
+    StackType_t task_stacks[kWorkerCount][kWorkerStackBytes / sizeof(StackType_t)] = {};
+    TaskHandle_t task_handles[kWorkerCount] = {nullptr, nullptr};
+    DualCoreWorkerTaskArgs task_args[kWorkerCount] = {};
+    Module *op = nullptr;
+    void *args[kWorkerCount] = {nullptr, nullptr};
+};
+
+void DualCoreWorkerTask(void *arg)
+{
+    auto *task_arg = static_cast<DualCoreWorkerTaskArgs *>(arg);
+    auto *runtime = task_arg->runtime;
+    const size_t slot = task_arg->slot;
+    while (true) {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        __sync_synchronize();
+        Module *op = runtime->op;
+        void *task_args = runtime->args[slot];
+        if (op != nullptr) {
+            op->forward_args(task_args);
+        }
+        xSemaphoreGive(runtime->completion);
+    }
+}
+
+bool InitDualCoreWorkerRuntime(DualCoreWorkerRuntime &runtime)
+{
+    runtime.dispatch_mutex = xSemaphoreCreateMutexStatic(&runtime.dispatch_mutex_buffer);
+    runtime.completion = xSemaphoreCreateCountingStatic(kWorkerCount, 0, &runtime.completion_buffer);
+    if (runtime.dispatch_mutex == nullptr || runtime.completion == nullptr) {
+        return false;
+    }
+
+    for (size_t i = 0; i < kWorkerCount; ++i) {
+        runtime.task_args[i].runtime = &runtime;
+        runtime.task_args[i].slot = i;
+        runtime.task_handles[i] = xTaskCreateStaticPinnedToCore(DualCoreWorkerTask,
+                                                                i == 0 ? "dl_mc0" : "dl_mc1",
+                                                                kWorkerStackBytes,
+                                                                &runtime.task_args[i],
+                                                                kWorkerDefaultPriority,
+                                                                runtime.task_stacks[i],
+                                                                &runtime.task_buffers[i],
+                                                                static_cast<BaseType_t>(i));
+        if (runtime.task_handles[i] == nullptr) {
+            return false;
+        }
+    }
+    return true;
+}
+
+DualCoreWorkerRuntime &GetDualCoreWorkerRuntime()
+{
+    static DualCoreWorkerRuntime runtime;
+    static const bool initialized = InitDualCoreWorkerRuntime(runtime);
+    assert(initialized);
+    (void)initialized;
+    return runtime;
+}
+
+#endif
+
+} // namespace
+
 Module::Module(const char *name, module_inplace_t inplace, quant_type_t quant_type) :
     inplace(inplace), quant_type(quant_type)
 {
@@ -48,6 +137,41 @@ void Module::run(std::vector<dl::TensorBase *> inputs, std::vector<dl::TensorBas
     }
 
     forward(&context, mode);
+}
+
+void module_forward_dual_core(Module *op, void *args1, void *args2)
+{
+#if CONFIG_FREERTOS_NUMBER_OF_CORES > 1
+    auto &runtime = GetDualCoreWorkerRuntime();
+    xSemaphoreTake(runtime.dispatch_mutex, portMAX_DELAY);
+    while (xSemaphoreTake(runtime.completion, 0) == pdTRUE) {
+    }
+
+    const UBaseType_t current_priority = uxTaskPriorityGet(xTaskGetCurrentTaskHandle());
+    for (size_t i = 0; i < kWorkerCount; ++i) {
+        vTaskPrioritySet(runtime.task_handles[i], current_priority);
+    }
+
+    runtime.op = op;
+    runtime.args[0] = args1;
+    runtime.args[1] = args2;
+    __sync_synchronize();
+
+    for (size_t i = 0; i < kWorkerCount; ++i) {
+        xTaskNotifyGive(runtime.task_handles[i]);
+    }
+    for (size_t i = 0; i < kWorkerCount; ++i) {
+        xSemaphoreTake(runtime.completion, portMAX_DELAY);
+    }
+
+    runtime.op = nullptr;
+    runtime.args[0] = nullptr;
+    runtime.args[1] = nullptr;
+    xSemaphoreGive(runtime.dispatch_mutex);
+#else
+    op->forward_args(args1);
+    op->forward_args(args2);
+#endif
 }
 
 } // namespace module


### PR DESCRIPTION
Title: dl: reuse static worker tasks in dual-core module runtime

## Summary

This PR fixes long-run performance drift in `module_forward_dual_core()` by replacing per-inference task/semaphore creation with two static worker tasks and static synchronization objects.

## Root cause

The current dual-core runtime creates and deletes:

- two pinned FreeRTOS tasks
- one counting semaphore

for every `module_forward_dual_core()` call.

Under a sustained high-frequency inference workload on ESP32-P4, this causes runtime degradation over time. In our downstream product workload, the degradation shows up as a clear increase in model inference latency, followed by a watchdog reset.

## Fix

`module_forward_dual_core()` now:

- initializes two static pinned worker tasks once
- reuses a static mutex to serialize dispatch
- reuses a static counting semaphore for completion
- updates task priority to match the caller before each dispatch
- wakes workers with `xTaskNotifyGive()` instead of creating/deleting tasks every call

This keeps the original dual-core execution model, but removes the per-inference task lifecycle overhead.

## Validation

Validated in a downstream ESP32-P4 firmware project that exercises `esp-dl` face detection + face feature inference continuously in multi-core mode.

Before this change:

- long-run latency drift appeared after about 70-110 seconds
- face detect latency increased from about 40 ms to about 130+ ms
- face feature latency increased from about 120 ms to about 200+ ms
- the system eventually hit WDT reset

After this change:

- 125 s run: stable
- 195 s run: stable
- 5 min run: stable
- no WDT resets
- no recurring latency drift

Representative downstream 5 min result:

- host result interval count: 1749
- min: 27 ms
- max: 227 ms
- avg: 171.0 ms
- >300 ms: 0

Representative downstream device-side tail latency:

- detect: about 34-52 ms
- feature: about 115-129 ms
- total: about 150-173 ms

## Notes

- This issue was reproduced and verified in a downstream project workload, not with a standalone `esp-dl` sample.
- I have intentionally kept the fix scoped to the common dual-core runtime path.
