### PR TITLE
fix(base): apply output requantization in C prelu_11c fallback (#319)

### DIFF
--- a/esp-dl/dl/base/dl_base_prelu.cpp
+++ b/esp-dl/dl/base/dl_base_prelu.cpp
@@ -10,12 +10,16 @@ void prelu_11c(feature_t *output_ptr, feature_t *input_ptr, const ArgsType<featu
     buffer_t temp;
     feature_t *alpha_ptr = (feature_t *)args.activation_alpha_ptr;
     for (size_t output_c = 0; output_c < args.output_channel; output_c++) {
-        output_ptr[output_c] = input_ptr[output_c];
-        if (output_ptr[output_c] < 0) {
-            temp =
-                DL_RIGHT_SHIFT((buffer_t)output_ptr[output_c] * (buffer_t)alpha_ptr[output_c], args.activation_shift);
-            tool::truncate(output_ptr[output_c], temp);
+        buffer_t x = (buffer_t)input_ptr[output_c];
+        if (x < 0) {
+            temp = DL_RIGHT_SHIFT(x * (buffer_t)alpha_ptr[output_c], args.activation_shift);
+        } else {
+            // Requantize the positive branch to the output exponent; previously the
+            // input was copied through unchanged, which is only correct when
+            // output->exponent == input->exponent.
+            temp = tool::shift_and_round(x * (buffer_t)args.output_scale, args.output_shift);
         }
+        tool::truncate(output_ptr[output_c], temp);
     }
 }
 


### PR DESCRIPTION
## Description

Fixes #319. The generic C/C++ PReLU kernel `prelu_11c` copied the positive branch through unchanged, ignoring the `output_scale` / `output_shift` that `get_activation_args()` computes from `output->exponent - input->exponent`. Whenever a PReLU node's output exponent differs from its input exponent, builds that take the C path (e.g. `IDF_TARGET=linux`, chips without PIE kernels) produced wrong values. The negative branch already requantizes through `activation_shift` and is unchanged.

Only the C fallback is touched; the ESP32-S3/P4 assembly kernels are not affected.

## Related

- Issue #319 (this fix); #320 reports a separate C-path problem with packed Conv filter layouts.

## Testing

Linux (host) target build of esp-dl, `human_face_feat_mfn_s8_v1.espdl`, random int8 input, every node's output compared against an independent int8 reference with each intermediate tensor given its own buffer:

- before: 12 of 43 PReLU nodes (all those with `out.exp != in.exp`) mismatch, e.g. `PRelu_7` 48 108 / 100 352 values wrong, max |diff| 63;
- after: all 103 nodes bit-exact.

End-to-end, the face detection + recognition pipeline on the host goes from degenerate embeddings to correct behaviour (same-identity cosine ≈ 0.7, cross-identity ≈ 0).

Not run on device (no PIE kernels are changed).

## Disclosure

Analysis and patch prepared with Claude (Anthropic's AI assistant) under the direction of Dr Liz James; the verification described above was executed, not inferred.

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed (none required).
- [ ] Tests are updated or added as necessary (no existing unit test covers the C PReLU path; happy to add one if you point me at the right harness).
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
