### PR TITLE
perf(base): hold kernel implementations in a plain function pointer

### DIFF
--- a/esp-dl/dl/base/dl_base.hpp
+++ b/esp-dl/dl/base/dl_base.hpp
@@ -103,8 +103,34 @@ typedef void (*n_wise_func_s16_t)(int16_t *, DL_S16_BUFFER_TYPE *, const ArgsTyp
 typedef void (*c_impl_func_s8_t)(int32_t *, int8_t *, const ArgsType<int8_t> &);
 typedef void (*n_wise_func_s8_t)(int8_t *, int32_t *, const ArgsType<int8_t> &);
 
+/**
+ * @brief Handle to a kernel implementation.
+ *
+ * A wrapper rather than a bare function pointer alias so that default construction is null: load_*() leaves it unset
+ * when no kernel matches the shape, and callers test `if (!i_impl_func)`.
+ */
 template <typename out_feature_t, typename in_feature_t, typename... feature_t>
-using ImplFunc_t = std::function<void(out_feature_t *, in_feature_t *, feature_t *..., void *)>;
+struct ImplFunc_t {
+    using func_t = void (*)(out_feature_t *, in_feature_t *, feature_t *..., void *);
+
+    func_t func = nullptr;
+
+    ImplFunc_t() = default;
+    ImplFunc_t(func_t f) : func(f) {}
+
+    ImplFunc_t &operator=(func_t f)
+    {
+        func = f;
+        return *this;
+    }
+
+    explicit operator bool() const { return func != nullptr; }
+
+    void operator()(out_feature_t *output, in_feature_t *input, feature_t *...inputs, void *args) const
+    {
+        func(output, input, inputs..., args);
+    }
+};
 
 // TODO:剥离出多核时 input output 的指针分配
 template <typename feature_t>


### PR DESCRIPTION
## Summary

`ImplFunc_t` — the handle every esp-dl operator uses to hold its selected kernel — is a
`std::function`, but nothing in the library ever puts anything except a plain function pointer
into one. Across `esp-dl/dl/base/`, all 139 lines naming the type are a declaration (24 bare, 36 with a
named function, 2 with `NULL`), a function parameter (56), an explicit template instantiation
(20), or the alias itself — and all 933 assignments to a variable of that type, across 30 files,
have a plain function name on the right-hand side. There is no lambda, no `std::bind`, no
capture, no bound state anywhere.

So the operators pay for type erasure they do not use. The cost lands in the worst place: in
`conv_operation_shell()` the handle is invoked from inside the innermost spatial loop, once per
output (y, x) position, so every one of those is an indirect call through `std::function`'s
invoker rather than one the compiler can see through. On top of that a 32-byte object is copied
each time a shell takes one by value, and a large amount of machinery is instantiated whose only
job is to erase a type the call site already knows.

This PR replaces it with a thin wrapper over the function pointer. Nothing at any call site
changes — declaration, assignment, the `if (!i_impl_func)` test and the call itself all keep
their existing spelling.

## Measured effect

ESP32-S3 (rev v0.2, 240 MHz, 8 MB octal PSRAM, QIO flash @ 80 MHz), ESP-IDF v5.5,
`examples/human_face_detect` built with `COMPILER_OPTIMIZATION_PERF`, timed on the device:

| | before | after | |
|---|---|---|---|
| end-to-end detect | 41,684 µs | 39,546 µs | **−5.1%** |
| Conv module | 37,029 µs | 35,001 µs | −5.5% |
| PRelu module | 907 µs | 800 µs | −11.8% |
| Concat module | 698 µs | 697 µs | unchanged |
| app image | 2,331,552 B | 2,314,400 B | −17 KB |
| `dl_base_conv2d.cpp.obj` | 658,816 B | 342,196 B | −48% |

Three runs per arm, repeated A-B-A-B against the same baseline to rule out drift. This workload
is essentially deterministic on this part: 5 baseline runs spanned 41,683-41,684 us and 8 patched
runs spanned 39,546-39,547 us, so the 2,138 us gap is roughly two thousand times the observed
run-to-run spread.

The Concat row is the control: Concat is the one timed module that does not go through
`ImplFunc_t`, and it is the one that does not move. Conv and PRelu, which do, both improve.

## Why a wrapper and not `using ImplFunc_t = void (*)(...)`

A bare function-pointer alias would be simpler, but it would silently break the loaders. 25 sites
declare the handle without an initializer —

```cpp
ImplFunc_t<int8_t, int8_t> i_impl_func;
ImplFunc_t<int8_t, int8_t> i_impl_func_sp;
load_conv2d_11cn_s8(i_impl_func, i_impl_func_sp, args);
if (!i_impl_func || !i_impl_func_sp) { ... }   // no kernel for this shape
```

— and rely on `std::function` default-constructing to null. A raw pointer would leave those
indeterminate and the null test would be undefined behaviour. The wrapper keeps the
default-null semantics exactly.

If you would rather have the plain alias, the alternative is the same header change plus
`= nullptr` on those 25 declarations. I went with the wrapper because it keeps the diff to one
file and cannot leave a site behind; happy to switch it if you prefer the other shape.

## Compatibility

`ImplFunc_t` is a public type in a public header. Downstream code that assigns a *named function*
to one is unaffected. Downstream code that stored a lambda or other stateful callable in one
would now fail to compile — a hard error at the assignment, not a silent behaviour change.

`#include <functional>` is deliberately left in `dl_base.hpp` so that translation units relying on
it transitively keep building.

## How the change was checked

- Every line naming `ImplFunc_t` (139) and every assignment to a variable of that type (933)
  was enumerated and classified by script; nothing fell outside the categories above. The only
  right-hand side that is not a bare function name is a ternary between two function names
  (`dl_base_conv2d.cpp:1136`), which is still a function pointer.
- Builds clean for ESP32-S3 and for ESP32-P4 — the P4 build matters because a large set of
  `i_impl_func = dl_esp32p4_*` assignment sites are `#if`-ed out of the S3 build.
- The example's detection output is unchanged: identical detection geometry on every run of every
  build, before and after.
- Formatting matches the repo's `.clang-format`.

What this does **not** include: I measured one example on one ESP32-S3 board with one IDF
version. I also did not separate how much of the 5.1% is the cheaper call and how much is the
17 KB smaller image relieving flash-cache pressure on an XIP target — both point the same way,
but the split is unmeasured.
